### PR TITLE
Output abi, networks and bytecode to different json files during packaging

### DIFF
--- a/scripts/package-npm.js
+++ b/scripts/package-npm.js
@@ -13,16 +13,23 @@ const mapDirs = {
 //                                or => key to extract from source file => dest file relative to module root
 const mapFiles = {
     "contracts/AgentFactory.sol": "sol/AgentFactory.sol",
-    "contracts/Registry.sol": "sol/Registry.sol",
+    "contracts/IRegistry.sol": "sol/IRegistry.sol",
     "build/contracts/AgentFactory.json": {
         "abi": "abi/AgentFactory.json",
         "networks": "networks/AgentFactory.json",
         "bytecode": "bytecode/AgentFactory.json"
     },
+    "build/contracts/AlphaRegistry.json": {
+        "abi": "abi/AlphaRegistry.json",
+        "networks": "networks/AlphaRegistry.json",
+        "bytecode": "bytecode/AlphaRegistry.json"
+    },
     "build/contracts/Registry.json": {
-        "abi": "abi/Registry.json",
         "networks": "networks/Registry.json",
         "bytecode": "bytecode/Registry.json"
+    },
+    "build/contracts/IRegistry.json": {
+        "abi": "abi/Registry.json"
     },
     "build/contracts/Agent.json": {
         "abi": "abi/Agent.json"


### PR DESCRIPTION
Disclaimer: do not check this in until the new Registry is out. This PR will be updated to output both the old Registry JSON files and the new Registry JSON files in the same npm package once the new Registry is checked in. The reason for having both the old and the new Registry JSONs in the same npm package is that the dapp will need to support both the old and the new Registry and npm doesn't have a concept of aliases like yarn does, so you cannot pull two different versions of the same package with a different name.

Changed package-npm.js script to take either a string with a file path or an object as the value for the source files map.

If an object is provided, each key will represent a key in the JSON source file that you want to save in a separate output file, and its value will be the destination file.