### PR TITLE
Add support for ERC165

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,22 @@ Includes alpha blockchain contracts, migrations, tests
 ## Contracts
 
 ### Agent
-* Per-service contract that manages the creation of Job instances at the request of consumers
+* Per-service contract that manages the creation of Job instances at the request of consumers.
 
 ### AgentFactory
-* Per-network contract that manages the creation of Agent instances at the request of service owners
+* Per-network contract that manages the creation of Agent instances at the request of service owners.
 
 ### Job
-* Per-service-invocation contract that performs escrow functionality with release of funds gated on a valid consumer signature
+* Per-service-invocation contract that performs escrow functionality with release of funds gated on a valid consumer signature.
 
 ### Registry
-* Per-network contract that maintains a mapping from name to agent address whose records can be updated and deprecated by the owner (first registrant) of the name
+* Per-network contract that maintains a registration structure including organizations, services, and type repositories. Consumers can query this registry by organization, service name, or tag in order to find AI services to use.
+
+## Interfaces
+
+| Name      | InterfaceID ([ERC-165](https://eips.ethereum.org/EIPS/eip-165)) | Source Code                              |
+|-----------|-----------------------------------------------------------------|------------------------------------------|
+| IRegistry | 0xbd523993                                                      | [IRegistry.sol](contracts/IRegistry.sol) |
 
 ## Deployed Contracts
 * AgentFactory (Kovan): [0x17c9c45ef8017862cd1628cd39f8ba1a9bc193ae](https://kovan.etherscan.io/address/0x17c9c45ef8017862cd1628cd39f8ba1a9bc193ae)

--- a/contracts/Agent.sol
+++ b/contracts/Agent.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.21;
 
-import "zeppelin-solidity/contracts/token/ERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./Job.sol";
 
 contract Agent {

--- a/contracts/Job.sol
+++ b/contracts/Job.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.21;
 
-import "zeppelin-solidity/contracts/token/ERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./Agent.sol";
 
 contract Job {

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,8 +1,9 @@
 pragma solidity ^0.4.24;
 
+import "openzeppelin-solidity/contracts/introspection/ERC165.sol";
 import "./IRegistry.sol";
 
-contract Registry is IRegistry {
+contract Registry is IRegistry, ERC165 {
 
     struct OrganizationRegistration {
         bytes32 organizationName;
@@ -678,5 +679,12 @@ contract Registry is IRegistry {
     function listTypeRepositoriesForTag(bytes32 tag) external view returns (bytes32[] orgNames, bytes32[] repositoryNames) {
         orgNames = typeReposByTag[tag].orgNames;
         repositoryNames = typeReposByTag[tag].itemNames;
+    }
+
+    // ERC165: https://eips.ethereum.org/EIPS/eip-165
+    function supportsInterface(bytes4 interfaceID) external view returns (bool) {
+        return
+            interfaceID == this.supportsInterface.selector || // ERC165
+            interfaceID == 0xbd523993; // IRegistry
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4446,7 +4446,8 @@
     "moment": {
       "version": "2.22.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -4680,6 +4681,11 @@
       "requires": {
         "mimic-fn": "1.2.0"
       }
+    },
+    "openzeppelin-solidity": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.11.0.tgz",
+      "integrity": "sha512-s4hFpQ9nMvFQBUuY0OJ7PfvSEprPcUph/YGvlgqJYQc6rNjsreRSj9Iq6ftTFI2anlECvWg/wWnNdPq4Tih1FA=="
     },
     "original-require": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   },
   "homepage": "https://github.com/singnet/alpha-blockchain#readme",
   "dependencies": {
+    "openzeppelin-solidity": "^1.11.0",
     "singularitynet-token-contracts": "1.0.0",
     "truffle": "4.1.13",
     "truffle-contract": "3.0.4",
-    "truffle-hdwallet-provider": "0.0.3",
-    "zeppelin-solidity": "1.4.0"
+    "truffle-hdwallet-provider": "0.0.3"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/test/TestERC165.sol
+++ b/test/TestERC165.sol
@@ -1,0 +1,68 @@
+pragma solidity ^0.4.24;
+
+import "truffle/Assert.sol";
+import "truffle/DeployedAddresses.sol";
+
+
+/**
+ * Tests that our interfaces support our published interface IDs from solidity, using the functions published in the
+ * erc165 spec.
+ *
+ * TODO: Use openzeppelin-solidity doesContractImplementInterface function if they ever merge our PR for this.
+ *       https://github.com/OpenZeppelin/openzeppelin-solidity/pull/1086
+ */
+contract TestERC165 {
+    bytes4 constant InvalidID   = 0xffffffff;
+    bytes4 constant ERC165ID    = 0x01ffc9a7;
+    bytes4 constant RegistryID  = 0xbd523993;
+
+    // adapted from https://eips.ethereum.org/EIPS/eip-165
+    function doesContractImplementInterface(address _contract, bytes4 _interfaceId) internal view returns (bool) {
+        uint256 success;
+        uint256 result;
+
+        (success, result) = noThrowCall(_contract, ERC165ID);
+        if ((success==0)||(result==0)) {
+            return false;
+        }
+
+        (success, result) = noThrowCall(_contract, InvalidID);
+        if ((success==0)||(result!=0)) {
+            return false;
+        }
+
+        (success, result) = noThrowCall(_contract, _interfaceId);
+        if ((success==1)&&(result==1)) {
+            return true;
+        }
+        return false;
+    }
+
+    // adapted from https://eips.ethereum.org/EIPS/eip-165
+    function noThrowCall(address _contract, bytes4 _interfaceId) internal view returns (uint256 success, uint256 result) {
+        bytes4 erc165ID = ERC165ID;
+
+        assembly {
+            let x := mload(0x40)               // Find empty storage location using "free memory pointer"
+            mstore(x, erc165ID)                // Place signature at begining of empty storage
+            mstore(add(x, 0x04), _interfaceId) // Place first argument directly next to signature
+
+            success := staticcall(
+                30000,         // 30k gas
+                _contract,     // To addr
+                x,             // Inputs are stored at location x
+                0x20,          // Inputs are 32 bytes long
+                x,             // Store output over input (saves space)
+                0x20           // Outputs are 32 bytes long
+            )
+
+            result := mload(x)                 // Load the result
+        }
+    }
+
+    function testRegistrySupportsERC165AndIRegistry() public {
+        bool registrySupportsRegistryID = doesContractImplementInterface(DeployedAddresses.Registry(), RegistryID);
+        
+        Assert.equal(registrySupportsRegistryID, true , "Registry should support ERC165 and implement RegistryID");
+    }
+}


### PR DESCRIPTION
- Computed the IRegistry interfaceID with solidity
- Added tests using the test code available in the ERC165 doc (CC0 license)
- `supportsInterface` compares the interfaceID directly instead of using a mapping. if we ever support more than 3 interfaces we should change this as per ERC165 doc.